### PR TITLE
new command mothership:reports:observerstimes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,3 +124,14 @@ mothership:images:resize
 Handy command, to minify the base-images. This will create a new directory named after the ```--dir``` parameter and create a smaller version of all existing images. Please be aware that in case you have a new image file with the same name, this command will not recognize that. In this case remove the existing file from the resized image directory and rerun the command
 
 ```magerun typehype:images:resize --dir=thumbnails --size=100```
+
+mothership:reports:observerstimes
+------------------------
+This is a *magerun* command to create a *csv* reports to find all the events and relative observers called for each 
+Magento page called in the browser during navigation.
+
+```
+magerun mothership:reports:observerstimes
+```
+
+[More doc](https://github.com/mothership-gmbh/magerun_mothership/tree/master/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports)

--- a/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/ObserversTimesCommand.php
+++ b/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/ObserversTimesCommand.php
@@ -51,7 +51,7 @@ class ObserversTimesCommand extends AbstractMagentoCommand
     protected function configure()
     {
         $this->setName('mothership:reports:observerstimes')
-            ->setDescription('Create a csv report with the execution workflow and observers execution time')
+            ->setDescription('Create a csv report with the execution workflow and observers execution times')
             ->addOption(
                 'bootleneck',
                 null,

--- a/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/ObserversTimesCommand.php
+++ b/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/ObserversTimesCommand.php
@@ -31,17 +31,29 @@ namespace Mothership_Addons\Reports;
 use N98\Magento\Command\AbstractMagentoCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Varien_Io_File;
 
 class ObserversTimesCommand extends AbstractMagentoCommand
 {
     protected $magento_root;
+    protected $observerlog_dir;
     protected $mage_php; //Mage.php original file from magento
     protected $app_php; //App.php original file from Magento
+    protected $dateStart;
+    protected $file_report = [];
+    protected $timestampfile;
 
     protected function configure()
     {
         $this->setName('mothership:reports:observerstimes')
-            ->setDescription('Create a csv report with the execution workflow with the execution time');
+            ->setDescription('Create a csv report with the execution workflow and observers execution time')
+            ->addOption(
+                'bootleneck',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'if set you have a detail analisys of the most expensive observers'
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -49,16 +61,46 @@ class ObserversTimesCommand extends AbstractMagentoCommand
         $this->handleSygnal();
         $this->output = $output;
         $this->magento_root = $this->getApplication()->getMagentoRootFolder();
+        $this->observerlog_dir = $this->magento_root . "/observerlogs";
+        if (!file_exists($this->observerlog_dir)) {
+            mkdir($this->observerlog_dir, 0777);
+        }
+        $this->dateStart = new \DateTime();
+        $bootleneck = false;
+        $info = array();
+
+        if ($input->getOption('bootleneck') == true) {
+            $bootleneck = true;
+            $this->output->writeln("<info>I will report bootlenecks</info>");
+        }
 
         $this->detectMagento($output);
         if ($this->initMagento()) {
-            $this->output->writeln("<info>Applying the patch</info>");
+            $this->output->writeln("<info>Applying the patch...</info>");
             $this->addPatch();
-            $this->output->writeln("<info>Start reporting</info>");
-            $this->output->writeln("<warning>Press Ctrl+z or Ctrl+c to stop</warning>");
-            $info = array();
+            $this->output->writeln("<info>Start reporting...</info>");
+            $this->output->writeln("<warning>Press Ctrl+z or Ctrl+c to stop!</warning>");
 
-            pcntl_sigwaitinfo(array(SIGTERM),$info);
+
+            touch($this->observerlog_dir.'/timestamp',time()-3600);
+            chmod($this->observerlog_dir.'/timestamp',0777);
+            $this->file_report = scandir($this->observerlog_dir);
+            $this->timestampfile = filemtime($this->observerlog_dir.'/timestamp');
+            if ($bootleneck) {
+                while (true) {
+                    $this->output->write("<info>.</info>");
+                    if (fileatime($this->observerlog_dir.'/timestamp') > $this->timestampfile) {
+                        $newfiles = scandir($this->observerlog_dir);
+                        $this->checkBootleneck($newfiles);
+                    }
+
+                    pcntl_sigtimedwait(array(SIGTERM), $info, 1);
+                }
+            } else {
+                pcntl_sigtimedwait(array(SIGTERM), $info, 1);
+            }
+
+
         }
 
         $this->output->writeln("<error>Init Magento fail</error>");
@@ -79,13 +121,22 @@ class ObserversTimesCommand extends AbstractMagentoCommand
     /**
      * add the patch
      */
-    protected function addPatch()
+    protected function addPatch($bootleneck = false)
     {
-        $patch = file_get_contents(dirname(__FILE__) . "/patch/observerstimes_dispatchEvent");
+        //$patch = file_get_contents(dirname(__FILE__) . "/patch/observerstimes_dispatchEvent");
         $this->mage_php = file_get_contents($this->magento_root . '/app/Mage.php');
 
-        $mage_log = str_replace("Varien_Profiler::start('DISPATCH EVENT:'", trim($patch) . "Varien_Profiler::start
-        ('DISPATCH EVENT:'", $this->mage_php);
+        /*$mage_log = str_replace("Varien_Profiler::start('DISPATCH EVENT:'", trim($patch) . "Varien_Profiler::start
+        ('DISPATCH EVENT:'", $this->mage_php);*/
+
+        $patch_mageRun = file_get_contents(dirname(__FILE__) . "/patch/observerstimes_mageRun");
+        $patch_mageRunEnd = file_get_contents(dirname(__FILE__) . "/patch/observerstimes_mageRunEnd");
+
+        $mage_log = str_replace("Varien_Profiler::start('mage');","Varien_Profiler::start('mage');".$patch_mageRun,
+            $this->mage_php);
+        $mage_log = str_replace("Varien_Profiler::stop('mage');",$patch_mageRunEnd."Varien_Profiler::stop('mage');",
+            $mage_log);
+
         file_put_contents($this->magento_root . "/app/Mage.php", $mage_log);
 
         $this->app_php = file_get_contents($this->magento_root . "/app/code/core/Mage/Core/Model/App.php");
@@ -93,6 +144,7 @@ class ObserversTimesCommand extends AbstractMagentoCommand
             "\$startime=microtime(true);Varien_Profiler::start('OBSERVER: '", $this->app_php);
 
         $patch_observer = file_get_contents(dirname(__FILE__) . "/patch/observerstimes_observer");
+
         $app_log = str_replace("Varien_Profiler::stop('OBSERVER: '", $patch_observer . "Varien_Profiler::stop
             ('OBSERVER: '", $app_log);
         file_put_contents($this->magento_root . "/app/code/core/Mage/Core/Model/App.php", $app_log);
@@ -100,11 +152,10 @@ class ObserversTimesCommand extends AbstractMagentoCommand
     }
 
     /**
-     * remove the patch
+     * remove the patchcount(scandir($this->magento_root . '/var/log'));
      */
     protected function removePatch()
     {
-
         file_put_contents($this->magento_root . "/app/Mage.php", $this->mage_php);
         file_put_contents($this->magento_root . "/app/code/core/Mage/Core/Model/App.php", $this->app_php);
     }
@@ -114,13 +165,44 @@ class ObserversTimesCommand extends AbstractMagentoCommand
         declare(ticks = 1);
 
         pcntl_signal(SIGINT, function ($signal) {
-            $this->output->writeln("<info>Handle signal: ".$signal."</info>");
+            $this->output->writeln("<info>Handle signal: " . $signal . "</info>");
             $this->stopObserver();
         });
 
         pcntl_signal(SIGTSTP, function ($signal) {
-            $this->output->writeln("<info>Handle signal: ".$signal."</info>");
+            $this->output->writeln("<info>Handle signal: " . $signal . "</info>");
             $this->stopObserver();
         });
     }
+
+
+    protected function checkBootleneck(array $newfiles)
+    {
+        $diff = array_diff($newfiles, $this->file_report);
+        foreach ($diff as $filelog) {
+            $this->output->writeln("<info>Analisyng: " . $filelog . "</info>");
+            $csvData = file_get_contents($this->observerlog_dir . '/' . $filelog);
+            $lines = explode(PHP_EOL, $csvData);
+            $bootlenecks = [];
+            foreach ($lines as $line) {
+                $myline = str_getcsv($line, ";");
+                print_r($myline);
+                if ($myline[5] > 0) {
+                    $this->output->writeln("<info>CIAO: ".$myline['5']."</info>");
+                    $bootlenecks[] = [$myline['1'], $myline['4'], $myline['3'], $myline['5']];
+                }
+            }
+
+            $filenameEx = explode("_", $filelog);
+            /*$url = str_replace(".log.csv", "",$filenameEx[2]);
+            $this->output->writeln("<info>Url: ".$url."</info>");*/
+            $table = $this->getHelper('table');
+            $table->setHeaders(['Observer', 'Model', 'Method', 'Time (ms)']);
+            $table->setRows($bootlenecks);
+            $table->render($this->output);
+        }
+        $this->file_report = $newfiles;
+        $this->timestampfile =fileatime($this->observerlog_dir.'/timestamp');
+    }
+
 }

--- a/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/README.md
+++ b/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/README.md
@@ -1,0 +1,29 @@
+REPORTS COMMAND
+-------------------------------------------
+This is a *magerun* command to create a *csv* reports to find all the events and relative observers called for each 
+Magento page called in the browser during navigation.
+
+#HOW
+
+- Call from terminal line:
+    ```
+    magerun mothership:reports:observerstimes
+    ```
+- the command will wait for your navigation into magento website 
+- Exit the command when you will finish with *ctrl+c* or *ctrl+z*
+
+You will find inside the folder *observerlogs* in the root directory a file csv for each page you navigated.
+
+Inside the csv you find all the events with the relative observers(model, method and execution time).
+
+##Option --bootleneck
+
+The option bootleneck gives you an immediate feedback for each observers that take more than 1ms for execution.
+
+In this way you can find easily potential bootlenecks.
+
+Run it with:
+
+```
+    magerun mothership:reports:observerstimes --bootleneck=true
+```

--- a/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/patch/observerstimes_dispatchEvent
+++ b/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/patch/observerstimes_dispatchEvent
@@ -1,1 +1,2 @@
-Mage::log($name, null, 'events.log.csv', true);
+$fp = $GLOBALS['fp'];
+fputcsv($fp, [$name,"","","","",""],';');

--- a/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/patch/observerstimes_mageRun
+++ b/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/patch/observerstimes_mageRun
@@ -4,5 +4,7 @@ $url = str_replace('/','_',$_SERVER['REQUEST_URI']);
 $filename = $basefilename."_".$now->format('YmdH').$url.".log.csv";
 
 $fp = fopen($filename, 'w');
+
+flock($fp, LOCK_EX);
 $GLOBALS['fp'] = $fp;
 fputcsv($fp, ["EVENT","OBSERVER","TYPE","METHOD","MODEL","TIME(ms)"],';');

--- a/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/patch/observerstimes_mageRun
+++ b/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/patch/observerstimes_mageRun
@@ -1,0 +1,8 @@
+$basefilename = __DIR__."/../observerlogs/observerstimes";
+$now = new \DateTime();
+$url = str_replace('/','_',$_SERVER['REQUEST_URI']);
+$filename = $basefilename."_".$now->format('YmdH').$url.".log.csv";
+
+$fp = fopen($filename, 'w');
+$GLOBALS['fp'] = $fp;
+fputcsv($fp, ["EVENT","OBSERVER","TYPE","METHOD","MODEL","TIME(ms)"],';');

--- a/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/patch/observerstimes_mageRunEnd
+++ b/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/patch/observerstimes_mageRunEnd
@@ -1,0 +1,2 @@
+fclose($fd);
+touch(__DIR__."/../observerlogs/timestamp",time());

--- a/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/patch/observerstimes_mageRunEnd
+++ b/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/patch/observerstimes_mageRunEnd
@@ -1,2 +1,3 @@
-fclose($fd);
-touch(__DIR__."/../observerlogs/timestamp",time());
+fflush($fp);            // flush output before releasing the lock
+flock($fp, LOCK_UN);
+fclose($fp);

--- a/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/patch/observerstimes_observer
+++ b/src/lib/n98-magerun/modules/mothership_addons/src/Mothership_Addons/Reports/patch/observerstimes_observer
@@ -1,2 +1,4 @@
 $diff = round(microtime(true) - $startime,3)*1000;
-Mage::log(';OBSERVER: '.$obsName.";TYPE: ".$obs['type'].";METHOD: ".$obs['method'].";MODEL: ".$obs['model'].";".$diff, null, 'events.log.csv', true);
+
+$fp = $GLOBALS['fp'];
+fputcsv($fp, ["",$obsName,$obs['type'],$obs['method'],$obs['model'],$diff],';');


### PR DESCRIPTION
- command to create a _csv_ reports to find all the events and relative observers called for each Magento page called in the browser during navigation
- option --bootleneck to discover potential bootleneck
